### PR TITLE
don't duplicate the "Exactly 'x'" and "Starts with 'x'" filters when …

### DIFF
--- a/scripts/components/result.jsx
+++ b/scripts/components/result.jsx
@@ -18,7 +18,8 @@ var ResultExpanded = React.createClass({
     gene = this.props.gene;
 
     details = this.props.details.map(function(detail) {
-      var component = React.createElement(detail.reactClass, {gene: gene, expanded: true});
+      var component = React.createElement(detail.reactClass, {gene: gene, expanded: true}),
+        key = gene.id + '-exp-' + detail.name;
       return (
         <div className="expanded-detail">
           <h4>{detail.name}</h4>
@@ -68,11 +69,12 @@ var ResultSmall = React.createClass({
     detailLinks = _.map(this.props.details, function(geneDetail) {
       var handler = handlerFactory(geneDetail),
         isActive = this.state.visibleDetail &&
-          geneDetail.name === this.state.visibleDetail.name,
+        geneDetail.name === this.state.visibleDetail.name,
+        key = gene.id + '-' + geneDetail.name,
         className = 'result-gene-detail-name' + (isActive ? ' active' : '');
 
       return (
-        <li className={className}>
+        <li key={key} className={className}>
           <a onClick={handler}>{geneDetail.name}</a>
         </li>
       );
@@ -98,7 +100,6 @@ var ResultSmall = React.createClass({
 });
 
 var Result = React.createClass({
-
   propTypes: {
     gene: React.PropTypes.object.isRequired
   },

--- a/scripts/components/result.jsx
+++ b/scripts/components/result.jsx
@@ -21,7 +21,7 @@ var ResultExpanded = React.createClass({
       var component = React.createElement(detail.reactClass, {gene: gene, expanded: true}),
         key = gene.id + '-exp-' + detail.name;
       return (
-        <div className="expanded-detail">
+        <div key={key} className="expanded-detail">
           <h4>{detail.name}</h4>
           {component}
         </div>

--- a/scripts/components/resultDetails/xrefs.jsx
+++ b/scripts/components/resultDetails/xrefs.jsx
@@ -75,8 +75,7 @@ var Xref = React.createClass({
   }
 });
 
-module.exports = React.createClass({
-
+var Xrefs = React.createClass({
   componentWillMount: function() {
     this.xrefs = _(this.props.gene)
     .pick(function(val, name) {
@@ -89,7 +88,7 @@ module.exports = React.createClass({
     .groupBy('label')
     .map(function(members, displayName) {
       return (
-        <Xref displayName={displayName} members={members} />
+        <Xref key={displayName} displayName={displayName} members={members} />
       )
     })
     .value();
@@ -109,3 +108,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+module.exports = Xrefs;

--- a/scripts/components/search.jsx
+++ b/scripts/components/search.jsx
@@ -113,8 +113,9 @@ var TextSearch = React.createClass({
     }
 
     var filters = _.map(search.query.filters, function(term, fq) {
+      var key = term.category + '-' + term.term;
       return (
-        <SearchFilter term={term} />
+        <SearchFilter key={key} term={term} />
       )
     });
 

--- a/scripts/components/suggest.jsx
+++ b/scripts/components/suggest.jsx
@@ -61,8 +61,9 @@ var SuggestCategory = React.createClass({
     var category, categorySuggestions, listClassName, result;
     category = this.props.category;
     categorySuggestions = category.suggestions.map(function (suggestedTerm) {
+      var key = suggestedTerm.category + '-' + suggestedTerm.key;
       return (
-        <Term suggestedTerm={suggestedTerm}/>
+        <Term key={key} suggestedTerm={suggestedTerm}/>
       );
     });
     listClassName = 'terms ' + category.className;

--- a/scripts/components/welcome.jsx
+++ b/scripts/components/welcome.jsx
@@ -18,7 +18,7 @@ var exampleQueries = [
   }
 ];
 
-module.exports = React.createClass({
+var Welcome = React.createClass({
   render: function () {
     var examples = _.map(exampleQueries, function(egQ, idx) {
       var resetFilters = function() {
@@ -63,3 +63,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+module.exports = Welcome;

--- a/scripts/stores/suggestStore.js
+++ b/scripts/stores/suggestStore.js
@@ -46,10 +46,12 @@ module.exports = Reflux.createStore({
 
     if(cached) {
       console.log('got results for ' + queryString + ' from cache');
-      promise = Q(cached);
+      promise = Q(_.cloneDeep(cached));
     }
     else {
       promise = this.suggestPromise(queryString)
+        .then(this.addQueryTermFactory(queryString))
+        .then(this.addCategoryClassNames)
         .then(function addToCache(response) {
           this.cache.set(queryString, _.cloneDeep(response));
           return response;
@@ -59,8 +61,6 @@ module.exports = Reflux.createStore({
 
     promise
       .then(this.removeAcceptedSuggestions)
-      .then(this.addQueryTermFactory(queryString))
-      .then(this.addCategoryClassNames)
       .then(this.findTopSuggestions)
       .then(this.suggestComplete)
       .catch(this.suggestError);
@@ -77,7 +77,7 @@ module.exports = Reflux.createStore({
   },
 
   addQueryTermFactory: function(queryString) {
-    return function(data) {
+    return function addQueryTerm(data) {
       var exact, beginsWith, textCategory;
       
       exact = {


### PR DESCRIPTION
…suggestions are retreived from the cache. Fixed in two ways: 1. clone the chached response before modification, 2. do some of the work before cacheing.

In addition, add key properties to result components to stop warnings in dev console.